### PR TITLE
chore: update test reporter name format in workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,9 @@
 name: check
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: dorny/test-reporter@v1
         if: ${{ !cancelled() }}
         with:
-          name: unit-test-result-linux-${{ matrix.module }}
+          name: unit-test-result-${{ matrix.module }}
           path: '**/test-results/**/*.xml'
           reporter: java-junit
           fail-on-error: false
@@ -117,7 +117,7 @@ jobs:
       - uses: dorny/test-reporter@v1
         if: ${{ !cancelled() }}
         with:
-          name: unit-test-result-linux-${{ matrix.module }}
+          name: unit-test-result-${{ matrix.module }}
           path: '**/test-results/**/*.xml'
           reporter: java-junit
           fail-on-error: false
@@ -144,7 +144,7 @@ jobs:
       - uses: dorny/test-reporter@v1
         if: ${{ !cancelled() }}
         with:
-          name: unit-test-result-linux-${{ matrix.module }}
+          name: unit-test-result-${{ matrix.module }}
           path: '**/test-results/**/*.xml'
           reporter: java-junit
           fail-on-error: false
@@ -171,7 +171,7 @@ jobs:
       - uses: dorny/test-reporter@v1
         if: ${{ !cancelled() }}
         with:
-          name: unit-test-result-linux-${{ matrix.module }}
+          name: unit-test-result-${{ matrix.module }}
           path: '**/test-results/**/*.xml'
           reporter: java-junit
           fail-on-error: false
@@ -195,7 +195,7 @@ jobs:
       - uses: dorny/test-reporter@v1
         if: ${{ !cancelled() }}
         with:
-          name: unit-test-result-linux-${{ matrix.module }}
+          name: unit-test-result-${{ matrix.module }}
           path: '**/test-results/**/*.xml'
           reporter: java-junit
           fail-on-error: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,30 +98,6 @@ jobs:
           reporter: java-junit
           fail-on-error: false
 
-  test-linux-arm64:
-    runs-on: ubuntu-24.04-arm
-    strategy:
-      fail-fast: false
-      matrix:
-        module: [
-          "linuxArm64",
-        ]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/java
-      - uses: ./.github/actions/gradle
-      - name: test
-        shell: bash
-        run: |
-          ./gradlew ${{ matrix.module }}Test
-      - uses: dorny/test-reporter@v1
-        if: ${{ !cancelled() }}
-        with:
-          name: unit-test-result-${{ matrix.module }}
-          path: '**/test-results/**/*.xml'
-          reporter: java-junit
-          fail-on-error: false
-
   test-mac-x64:
     runs-on: macos-13
     strategy:


### PR DESCRIPTION
This pull request includes a series of changes to the `jobs:` section in the `.github/workflows/check.yml` file. The changes involve modifying the naming convention for unit test results to make them more consistent and platform-independent.

Changes to unit test result naming:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L96-R96): Updated the `name` field for unit test results by removing the platform-specific (`linux`) part of the name, making it more generic and applicable to any platform. [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L96-R96) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L120-R120) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L147-R147) [[4]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L174-R174) [[5]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L198-R198)