### PR TITLE
chore: add GitHub workflow for Gradle dependency report

### DIFF
--- a/.github/workflows/dependency-report.yml
+++ b/.github/workflows/dependency-report.yml
@@ -1,0 +1,24 @@
+# $schema: https://json.schemastore.org/github-workflow.json
+name: submit gradle dependency report
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflows }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/java
+      - uses: gradle/actions/dependency-submission@v4
+        with:
+          gradle-version: wrapper
+          dependency-resolution-task: 'resolveAllDependencies'
+          validate-wrappers: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to generate and submit a Gradle dependency report. The workflow is triggered manually or upon a push to the main branch.

New GitHub Actions workflow:

* [`.github/workflows/dependency-report.yml`](diffhunk://#diff-094eafb2d27dd9a0bec52ebebc28b42c1d45ac4753c7ad40470b90d381f3b5feR1-R24): Added a new workflow named `submit gradle dependency report` which runs on `ubuntu-latest` and includes steps for checking out the repository, setting up Java, and submitting the dependency report using Gradle.