### PR TITLE
chore: add Dependabot configuration for Gradle and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "deps(gradle)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "deps(github-actions)"
+
+  # https://github.com/dependabot/dependabot-core/issues/5137
+  - package-ecosystem: "github-actions"
+    directory: ".github/actions/gradle"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "deps(github-actions)"
+
+  - package-ecosystem: "github-actions"
+    directory: ".github/actions/java"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "deps(github-actions)"
+
+  - package-ecosystem: "github-actions"
+    directory: ".github/actions/konan"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "deps(github-actions)"


### PR DESCRIPTION
This pull request introduces a new `dependabot` configuration to automate dependency updates for various ecosystems in the repository. The configuration schedules daily checks and updates for dependencies at a specified time and timezone.

Key changes include:

* Added `dependabot` configuration file `.github/dependabot.yml` to automate dependency updates for `gradle` and `github-actions` ecosystems. The updates are scheduled to run daily at 09:00 Tokyo time.…ates