### PR TITLE
chore: update concurrency cancellation condition in workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflows }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file `.github/workflows/check.yml`. The change modifies the `cancel-in-progress` setting to ensure that workflows are only canceled if the reference is not the 'main' branch.

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L16-R16): Modified the `cancel-in-progress` setting to use a conditional expression that prevents cancellation if the reference is 'main'.