### PR TITLE
chore: update concurrency group names in workflow files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ on:
       - reopened
 
 concurrency:
-  group: ${{ github.workflows }}-${{ github.head_ref || github.ref }}
+  group: check-${{ github.workflows }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
 permissions:

--- a/.github/workflows/dependency-report.yml
+++ b/.github/workflows/dependency-report.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflows }}-${{ github.head_ref || github.ref }}
+  group: dependency-report-${{ github.workflows }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflows }}-${{ github.head_ref || github.ref }}
+  group: pages-${{ github.workflows }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
This pull request includes changes to the concurrency group names in several GitHub workflow files. The updates ensure that each workflow has a unique concurrency group name, which helps to avoid conflicts and improve workflow management.

Changes to concurrency group names:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L15-R15): Updated the concurrency group name to `check-${{ github.workflows }}-${{ github.head_ref || github.ref }}`.
* [`.github/workflows/dependency-report.yml`](diffhunk://#diff-094eafb2d27dd9a0bec52ebebc28b42c1d45ac4753c7ad40470b90d381f3b5feL11-R11): Updated the concurrency group name to `dependency-report-${{ github.workflows }}-${{ github.head_ref || github.ref }}`.
* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L10-R10): Updated the concurrency group name to `pages-${{ github.workflows }}-${{ github.head_ref || github.ref }}`.