### PR TITLE
chore: typo

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ on:
       - reopened
 
 concurrency:
-  group: check-${{ github.workflows }}-${{ github.head_ref || github.ref }}
+  group: check-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
 permissions:

--- a/.github/workflows/dependency-report.yml
+++ b/.github/workflows/dependency-report.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 concurrency:
-  group: dependency-report-${{ github.workflows }}-${{ github.head_ref || github.ref }}
+  group: dependency-report-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: pages-${{ github.workflows }}-${{ github.head_ref || github.ref }}
+  group: pages-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.log
 *.iml
 .idea/artifacts
+.idea/AndroidProjectSystem.xml
 .idea/androidTestResultsUserPreferences.xml
 .idea/compiler.xml
 .idea/inspectionProfiles


### PR DESCRIPTION
This pull request includes changes to multiple GitHub Actions workflow files to correct the `concurrency` group naming. The changes ensure that the correct `github.workflow` context is used instead of `github.workflows`.

Changes to GitHub Actions workflow files:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L15-R15): Updated the `concurrency` group to use `github.workflow` instead of `github.workflows`.
* [`.github/workflows/dependency-report.yml`](diffhunk://#diff-094eafb2d27dd9a0bec52ebebc28b42c1d45ac4753c7ad40470b90d381f3b5feL11-R11): Updated the `concurrency` group to use `github.workflow` instead of `github.workflows`.
* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L10-R10): Updated the `concurrency` group to use `github.workflow` instead of `github.workflows`.