### PR TITLE
chore: update tag filter

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,8 +4,8 @@ name: deploy dokka content to Pages
 on:
   push:
     tags:
-      - "[0-9].[0-9]+.[0-9]+"
-      - "[0-9].[0-9]+.[0-9]+-[a-zA-Z0-9]+[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+[0-9]+"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,8 +4,8 @@ name: deploy dokka content to Pages
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+.[0-9]+"
+      - "[0-9].[0-9]+.[0-9]+"
+      - "[0-9].[0-9]+.[0-9]+-[a-zA-Z0-9]+[0-9]+"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/pages.yml` file. The change modifies the regular expression used for matching tags in the `push` event trigger.

* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L8-R8): Updated the regular expression for pre-release tags in the `push` event to remove the dot (`.`) before the numeric suffix, ensuring compatibility with the intended tag format.