### PR TITLE
fix: update artifact source elements configuration

### DIFF
--- a/auto-mutton-recipe-compose/build.gradle
+++ b/auto-mutton-recipe-compose/build.gradle
@@ -146,8 +146,5 @@ tasks.register("sampleSourcesJar", Jar) {
 }
 
 afterEvaluate {
-    artifacts.metadataSourcesElements(sampleSourcesJar)
-    artifacts.releaseSourcesElements(sampleSourcesJar)
-    artifacts.jvmSourcesElements(sampleSourcesJar)
-    artifacts.linuxX64SourcesElements(sampleSourcesJar)
+    artifacts.add("metadataSourcesElements", sampleSourcesJar)
 }


### PR DESCRIPTION
```
* What went wrong:
A problem was found with the configuration of task ':auto-mutton-recipe-compose:signJvmPublication' (type 'Sign').
  - Gradle detected a problem with the following location: '/home/runner/work/AutoMuttonRecipe/AutoMuttonRecipe/auto-mutton-recipe-compose/build/libs/auto-mutton-recipe-compose-1.3.0-samples-sources.jar.asc'.
    
    Reason: Task ':auto-mutton-recipe-compose:publishAndroidReleasePublicationToMavenCentralRepository' uses this output of task ':auto-mutton-recipe-compose:signJvmPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':auto-mutton-recipe-compose:signJvmPublication' as an input of ':auto-mutton-recipe-compose:publishAndroidReleasePublicationToMavenCentralRepository'.
      2. Declare an explicit dependency on ':auto-mutton-recipe-compose:signJvmPublication' from ':auto-mutton-recipe-compose:publishAndroidReleasePublicationToMavenCentralRepository' using Task#dependsOn.
      3. Declare an explicit dependency on ':auto-mutton-recipe-compose:signJvmPublication' from ':auto-mutton-recipe-compose:publishAndroidReleasePublicationToMavenCentralRepository' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.13/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```