### PR TITLE
chore: group dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    groups:
+      compose:
+        patterns:
+          - "androidx.compose*"
+          - "androidx.constraintlayout:constraintlayout-compose*"
     commit-message:
       prefix: "deps(gradle)"
 


### PR DESCRIPTION
This pull request updates the Dependabot configuration to introduce grouping for Compose-related dependencies. This change aims to improve dependency management by organizing updates for specific libraries under a single group.

Configuration changes:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R14): Added a `groups` section with a `compose` group to include patterns matching `androidx.compose*` and `androidx.constraintlayout:constraintlayout-compose*`.